### PR TITLE
Do not enforce line length for comments

### DIFF
--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -26,7 +26,10 @@ profile = "black"
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
 select = ["E", "F"]
-ignore = []
+ignore = [
+    # E501: Do not enforce line length; black does this for code and we do not care about comments / docs
+    "E501"
+]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]


### PR DESCRIPTION
We ignore E501 in ruff, but still keep black, that will ignore comments but ensure that other lines are not beyond the character limit.