### PR TITLE
Replace pyright with mypy

### DIFF
--- a/.pre-commit-config.yaml.jinja
+++ b/.pre-commit-config.yaml.jinja
@@ -15,19 +15,19 @@ repos:
   # In case of enabling auto fix, it should be placed before other formatting tools.
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.0.289
+    rev: v0.1.15
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.1.1
     hooks:
       - id: black
         args: [--target-version=py{{ python_version | replace(".", "") }}]
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
 
@@ -49,7 +49,7 @@ repos:
         args: [requirements-dev.in]
         files: ^requirements-dev\.(in|txt)$
 
-  - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.327
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
     hooks:
-      - id: pyright
+      - id: mypy

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ It includes:
     - isort
 - Linters
     - ruff
-- Static analyzers
-    - pyright
+- Type checkers
+    - mypy
 - pre-commit adds hooks for:
     - check-yaml
     - check-case-conflict
@@ -31,6 +31,7 @@ It includes:
     - ruff
     - black
     - pytest
+    - mypy
 
 ## Usage
 

--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -70,15 +70,31 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # Assume Python {{ python_version }}.
 target-version = "py{{ python_version | replace('.', '') }}"
 
-[tool.pyright]
-# For pre-commit to work. See contributing.md#pre-commit
-venvPath = "."
-venv = ".venv"
 
-exclude = ["**/node_modules",
-    "**/__pycache__",
-]
-defineConstant = { DEBUG = true }
+[tool.mypy]
+python_version = "{{python_version}}"
+python_executable = ".venv/bin/python"
+# Warns about per-module sections in the config file that do not match any files processed when invoking mypy.
+warn_unused_configs = true
+# Shows a warning when returning a value with type Any from a function declared with a non-Any return type.
+warn_return_any = true
+# Changes the treatment of arguments with a default value of None by not implicitly making their type Optional.
+no_implicit_optional = true
+# Prohibit equality checks, identity checks, and container checks between non-overlapping types.
+strict_equality = true
+# Warns about casting an expression to its inferred type.
+warn_redundant_casts = true
+# No error on unneeded # type: ignore comments.
+warn_unused_ignores = true
+implicit_reexport = true
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
 
-pythonVersion = "{{ python_version }}"
-strict = true
+
+[[tool.mypy.overrides]]
+# module = ["wandb.*", "fastprogress.*", "sklearn.*"]
+# follow_imports = "skip"
+# follow_imports_for_stubs = true
+# Suppresses error messages about imports that cannot be resolved.
+# ignore_missing_imports = true

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -1,8 +1,8 @@
-black>=23.7.0
-isort>=5.12.0
-pre-commit>=3.4
-pip-tools>=7.3.0
+black>=24.1.1
 build>=1.0.3
-pyright>=1.1.327
-ruff>=0.0.289
+isort>=5.12.0
+mypy>=1.8.0
+pip-tools>=7.3.0
+pre-commit>=3.4
 pytest>=7.4
+ruff>=0.0.289

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements-dev.in
 #
-black==23.9.1
+black==24.1.1
     # via -r requirements-dev.in
 build==1.0.3
     # via
@@ -16,52 +16,54 @@ click==8.1.7
     # via
     #   black
     #   pip-tools
-distlib==0.3.7
+distlib==0.3.8
     # via virtualenv
-filelock==3.12.4
+filelock==3.13.1
     # via virtualenv
-identify==2.5.28
+identify==2.5.33
     # via pre-commit
 iniconfig==2.0.0
     # via pytest
-isort==5.12.0
+isort==5.13.2
+    # via -r requirements-dev.in
+mypy==1.8.0
     # via -r requirements-dev.in
 mypy-extensions==1.0.0
-    # via black
-nodeenv==1.8.0
     # via
-    #   pre-commit
-    #   pyright
-packaging==23.1
+    #   black
+    #   mypy
+nodeenv==1.8.0
+    # via pre-commit
+packaging==23.2
     # via
     #   black
     #   build
     #   pytest
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
 pip-tools==7.3.0
     # via -r requirements-dev.in
-platformdirs==3.10.0
+platformdirs==4.2.0
     # via
     #   black
     #   virtualenv
-pluggy==1.3.0
+pluggy==1.4.0
     # via pytest
-pre-commit==3.4.0
+pre-commit==3.6.0
     # via -r requirements-dev.in
 pyproject-hooks==1.0.0
     # via build
-pyright==1.1.327
-    # via -r requirements-dev.in
-pytest==7.4.2
+pytest==8.0.0
     # via -r requirements-dev.in
 pyyaml==6.0.1
     # via pre-commit
-ruff==0.0.289
+ruff==0.1.15
     # via -r requirements-dev.in
-virtualenv==20.24.5
+typing-extensions==4.9.0
+    # via mypy
+virtualenv==20.25.0
     # via pre-commit
-wheel==0.41.2
+wheel==0.42.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Also, update linters and formatters

After a few months using pyright... I have found a lot of small issues that hinders development.

mypy is slow, but it is tweakable and most of the libraries adapt to it.